### PR TITLE
logging revamp

### DIFF
--- a/ensembl_anno.py
+++ b/ensembl_anno.py
@@ -5579,7 +5579,7 @@ if __name__ == "__main__":
     file_handler.setFormatter(logging_formatter_time_message)
     logger.addHandler(file_handler)
 
-    logger.info(f"work directory: {work_dir}")
+    logger.info("work directory: %s" % work_dir)
 
     if not os.path.exists(work_dir):
         logger.info("Work dir does not exist, will create")

--- a/ensembl_anno.py
+++ b/ensembl_anno.py
@@ -23,18 +23,31 @@ import logging
 import math
 import multiprocessing
 import os
+import pathlib
 import random
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 
 from pathlib import Path
 
 
-# filename=os.environ[work_dir] + "myLogFile.log"
-# logging.basicConfig(filename, filemode='w', format='%(asctime)s,%(msecs)d %(name)s - %(levelname)s - %(message)s',datefmt='%H:%M:%S', level=logging.DEBUG)
-# logging.warning('This will get logged to a file')
+# logging formats
+logging_formatter_time_message = logging.Formatter(
+    fmt="%(asctime)s | %(levelname)s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+# set up base logger
+logger = logging.getLogger("main_logger")
+logger.setLevel(logging.DEBUG)
+logger.propagate = False
+# create console handler and add to logger
+console_handler = logging.StreamHandler(sys.stderr)
+console_handler.setLevel(logging.DEBUG)
+console_handler.setFormatter(logging_formatter_time_message)
+logger.addHandler(console_handler)
 
 
 def create_dir(main_output_dir, dir_name):
@@ -45,18 +58,18 @@ def create_dir(main_output_dir, dir_name):
         target_dir = main_output_dir
 
     if os.path.exists(target_dir):
-        logging.warning("Directory already exists, will not create again")
+        logger.warning("Directory already exists, will not create again")
         return target_dir
 
-    logging.info("Attempting to create target dir: %s" % target_dir)
+    logger.info("Attempting to create target dir: %s" % target_dir)
 
     try:
         os.mkdir(target_dir)
 
     except OSError:
-        logging.error("Creation of the dir failed, path used: %s" % target_dir)
+        logger.error("Creation of the dir failed, path used: %s" % target_dir)
     else:
-        logging.info(
+        logger.info(
             "Successfully created the dir on the following path: %s" % target_dir
         )
 
@@ -82,7 +95,7 @@ def load_results_to_ensembl_db(
         main_output_dir, "annotation_output", "annotation.gtf"
     )
     if os.path.exists(annotation_results_gtf_file):
-        logging.info("Loading main geneset to db")
+        logger.info("Loading main geneset to db")
         batch_size = 200
         load_type = "gene"
         analysis_name = "ensembl"
@@ -101,7 +114,7 @@ def load_results_to_ensembl_db(
             num_threads,
         )
     else:
-        logging.error(
+        logger.error(
             "Did not find the main gene annotation file, so not loading. Path checked:\n"
             + annotation_results_gtf_file
         )
@@ -110,7 +123,7 @@ def load_results_to_ensembl_db(
         main_output_dir, "rfam_output", "annotation.gtf"
     )
     if os.path.exists(rfam_results_gtf_file):
-        logging.info("Loading Rfam-based sncRNA genes to db")
+        logger.info("Loading Rfam-based sncRNA genes to db")
         batch_size = 500
         load_type = "gene"
         analysis_name = "ncrna"
@@ -129,7 +142,7 @@ def load_results_to_ensembl_db(
             num_threads,
         )
     else:
-        logging.error(
+        logger.error(
             "Did not find an Rfam annotation file, so not loading. Path checked:\n"
             + rfam_results_gtf_file
         )
@@ -138,7 +151,7 @@ def load_results_to_ensembl_db(
         main_output_dir, "trnascan_output", "annotation.gtf"
     )
     if os.path.exists(trnascan_results_gtf_file):
-        logging.info("Loading tRNAScan-SE tRNA genes to db")
+        logger.info("Loading tRNAScan-SE tRNA genes to db")
         batch_size = 500
         load_type = "gene"
         analysis_name = "ncrna"
@@ -157,7 +170,7 @@ def load_results_to_ensembl_db(
             num_threads,
         )
     else:
-        logging.error(
+        logger.error(
             "Did not find an tRNAScan-SE annotation file, so not loading. Path checked:\n"
             + trnascan_results_gtf_file
         )
@@ -166,7 +179,7 @@ def load_results_to_ensembl_db(
         main_output_dir, "dust_output", "annotation.gtf"
     )
     if os.path.exists(dust_results_gtf_file):
-        logging.info("Loading Dust repeats to db")
+        logger.info("Loading Dust repeats to db")
         batch_size = 500
         load_type = "single_line_feature"
         analysis_name = "dust"
@@ -185,14 +198,14 @@ def load_results_to_ensembl_db(
             num_threads,
         )
     else:
-        logging.error(
+        logger.error(
             "Did not find a Dust annotation file, so not loading. Path checked:\n"
             + dust_results_gtf_file
         )
 
     red_results_gtf_file = os.path.join(main_output_dir, "red_output", "annotation.gtf")
     if os.path.exists(red_results_gtf_file):
-        logging.info("Loading Red repeats to db")
+        logger.info("Loading Red repeats to db")
         batch_size = 500
         load_type = "single_line_feature"
         analysis_name = "repeatdetector"
@@ -211,14 +224,14 @@ def load_results_to_ensembl_db(
             num_threads,
         )
     else:
-        logging.error(
+        logger.error(
             "Did not find a Red annotation file, so not loading. Path checked:\n"
             + red_results_gtf_file
         )
 
     trf_results_gtf_file = os.path.join(main_output_dir, "trf_output", "annotation.gtf")
     if os.path.exists(trf_results_gtf_file):
-        logging.info("Loading TRF repeats to db")
+        logger.info("Loading TRF repeats to db")
         batch_size = 500
         load_type = "single_line_feature"
         analysis_name = "trf"
@@ -237,14 +250,14 @@ def load_results_to_ensembl_db(
             num_threads,
         )
     else:
-        logging.error(
+        logger.error(
             "Did not find a TRF annotation file, so not loading. Path checked:\n"
             + trf_results_gtf_file
         )
 
     cpg_results_gtf_file = os.path.join(main_output_dir, "cpg_output", "annotation.gtf")
     if os.path.exists(cpg_results_gtf_file):
-        logging.info("Loading CpG islands to db")
+        logger.info("Loading CpG islands to db")
         batch_size = 500
         load_type = "single_line_feature"
         analysis_name = "cpg"
@@ -263,7 +276,7 @@ def load_results_to_ensembl_db(
             num_threads,
         )
     else:
-        logging.error(
+        logger.error(
             "Did not find a CpG annotation file, so not loading. Path checked:\n"
             + cpg_results_gtf_file
         )
@@ -272,7 +285,7 @@ def load_results_to_ensembl_db(
         main_output_dir, "eponine_output", "annotation.gtf"
     )
     if os.path.exists(eponine_results_gtf_file):
-        logging.info("Loading Eponine repeats to db")
+        logger.info("Loading Eponine repeats to db")
         batch_size = 500
         load_type = "single_line_feature"
         analysis_name = "eponine"
@@ -291,12 +304,12 @@ def load_results_to_ensembl_db(
             num_threads,
         )
     else:
-        logging.error(
+        logger.error(
             "Did not find an Eponine annotation file, so not loading. Path checked:\n"
             + eponine_results_gtf_file
         )
 
-    logging.info("Finished loading records to db")
+    logger.info("Finished loading records to db")
 
 
 def generic_load_records_to_ensembl_db(
@@ -387,11 +400,11 @@ def multiprocess_load_records_to_ensembl_db(
         if load_to_ensembl_db == "single_transcript_genes":
             loading_cmd.append("-make_single_transcript_genes")
 
-    logging.info(" ".join(loading_cmd))
+    logger.info(" ".join(loading_cmd))
     subprocess.run(loading_cmd)
     gtf_temp_out.close()
     os.remove(gtf_temp_file_path)  # doesn't seem to be working
-    logging.info("Finished: " + gtf_temp_file_path)
+    logger.info("Finished: " + gtf_temp_file_path)
     gc.collect()
 
 
@@ -544,17 +557,17 @@ def run_repeatmasker_regions(
     repeatmasker_output_dir = create_dir(main_output_dir, "repeatmasker_output")
     os.chdir(repeatmasker_output_dir)
 
-    logging.info("Skip analysis if the gtf file already exists")
+    logger.info("Skip analysis if the gtf file already exists")
     output_file = os.path.join(repeatmasker_output_dir, "annotation.gtf")
     if os.path.exists(output_file):
         transcript_count = check_gtf_content(output_file, "repeat")
         if transcript_count > 0:
-            logging.info("Repeatmasker gtf file exists")
+            logger.info("Repeatmasker gtf file exists")
             return
     else:
-        logging.info("No gtf file, go on with the analysis")
+        logger.info("No gtf file, go on with the analysis")
 
-    logging.info("Creating list of genomic slices")
+    logger.info("Creating list of genomic slices")
     seq_region_lengths = get_seq_region_lengths(genome_file, 5000)
     slice_ids = create_slice_ids(seq_region_lengths, 1000000, 0, 5000)
 
@@ -595,7 +608,7 @@ def run_repeatmasker_regions(
             repeatmasker_output_dir,
         ]
 
-    logging.info("Running RepeatMasker")
+    logger.info("Running RepeatMasker")
     pool = multiprocessing.Pool(int(num_threads))
     tasks = []
     for slice_id in slice_ids:
@@ -624,7 +637,7 @@ def multiprocess_repeatmasker(
     start = slice_id[1]
     end = slice_id[2]
 
-    logging.info(
+    logger.info(
         "Processing slice to find repeats with RepeatMasker: "
         + region_name
         + ":"
@@ -652,7 +665,7 @@ def multiprocess_repeatmasker(
 
     repeatmasker_cmd = generic_repeatmasker_cmd.copy()
     repeatmasker_cmd.append(region_fasta_file_path)
-    logging.info(" ".join(repeatmasker_cmd))
+    logger.info(" ".join(repeatmasker_cmd))
     subprocess.run(repeatmasker_cmd)
 
     create_repeatmasker_gtf(
@@ -748,17 +761,17 @@ def run_eponine_regions(
 
     eponine_output_dir = create_dir(main_output_dir, "eponine_output")
 
-    logging.info("Skip analysis if the gtf file already exists")
+    logger.info("Skip analysis if the gtf file already exists")
     output_file = os.path.join(eponine_output_dir, "annotation.gtf")
     if os.path.exists(output_file):
         transcript_count = check_gtf_content(output_file, "simple_feature")
         if transcript_count > 0:
-            logging.info("Eponine gtf file exists")
+            logger.info("Eponine gtf file exists")
             return
     else:
-        logging.info("No gtf file, go on with the analysis")
+        logger.info("No gtf file, go on with the analysis")
 
-    logging.info("Creating list of genomic slices")
+    logger.info("Creating list of genomic slices")
     seq_region_lengths = get_seq_region_lengths(genome_file, 5000)
     slice_ids = create_slice_ids(seq_region_lengths, 1000000, 0, 5000)
 
@@ -771,7 +784,7 @@ def run_eponine_regions(
         threshold,
         "-seq",
     ]
-    logging.info("Running Eponine")
+    logger.info("Running Eponine")
     pool = multiprocessing.Pool(int(num_threads))
     tasks = []
     for slice_id in slice_ids:
@@ -798,7 +811,7 @@ def multiprocess_eponine(
     start = slice_id[1]
     end = slice_id[2]
 
-    logging.info(
+    logger.info(
         "Processing slice to find transcription start sites with Eponine: "
         + region_name
         + ":"
@@ -827,7 +840,7 @@ def multiprocess_eponine(
     eponine_cmd = generic_eponine_cmd.copy()
     eponine_cmd.append(region_fasta_file_path)
 
-    logging.info(" ".join(eponine_cmd))
+    logger.info(" ".join(eponine_cmd))
     subprocess.run(eponine_cmd, stdout=eponine_out)
     eponine_out.close()
 
@@ -888,21 +901,21 @@ def run_cpg_regions(genome_file, cpg_path, main_output_dir, num_threads):
     check_exe(cpg_path)
     cpg_output_dir = create_dir(main_output_dir, "cpg_output")
 
-    logging.info("Skip analysis if the gtf file already exists")
+    logger.info("Skip analysis if the gtf file already exists")
     output_file = os.path.join(cpg_output_dir, "annotation.gtf")
     if os.path.exists(output_file):
         transcript_count = check_gtf_content(output_file, "simple_feature")
         if transcript_count > 0:
-            logging.info("Cpg gtf file exists")
+            logger.info("Cpg gtf file exists")
             return
     else:
-        logging.info("No gtf file, go on with the analysis")
+        logger.info("No gtf file, go on with the analysis")
 
-    logging.info("Creating list of genomic slices")
+    logger.info("Creating list of genomic slices")
     seq_region_lengths = get_seq_region_lengths(genome_file, 5000)
     slice_ids = create_slice_ids(seq_region_lengths, 1000000, 0, 5000)
 
-    logging.info("Running CpG")
+    logger.info("Running CpG")
     pool = multiprocessing.Pool(int(num_threads))
     tasks = []
     for slice_id in slice_ids:
@@ -927,7 +940,7 @@ def multiprocess_cpg(cpg_path, slice_id, genome_file, cpg_output_dir):
     start = slice_id[1]
     end = slice_id[2]
 
-    logging.info(
+    logger.info(
         "Processing slice to find CpG islands with cpg_lh: "
         + region_name
         + ":"
@@ -952,7 +965,7 @@ def multiprocess_cpg(cpg_path, slice_id, genome_file, cpg_output_dir):
     cpg_out = open(cpg_output_file_path, "w+")
 
     cpg_cmd = [cpg_path, region_fasta_file_path]
-    logging.info(" ".join(cpg_cmd))
+    logger.info(" ".join(cpg_cmd))
     subprocess.run(cpg_cmd, stdout=cpg_out)
     cpg_out.close()
 
@@ -1018,29 +1031,29 @@ def run_trnascan_regions(
 
     if not trnascan_path:
         trnascan_path = "/hps/software/users/ensembl/ensw/C8-MAR21-sandybridge/linuxbrew/bin/tRNAscan-SE"
-    logging.info(trnascan_path)
+    logger.info(trnascan_path)
     if not trnascan_filter_path:
         trnascan_filter_path = "/hps/software/users/ensembl/ensw/C8-MAR21-sandybridge/linuxbrew/bin/EukHighConfidenceFilter"
-    logging.info(trnascan_filter_path)
+    logger.info(trnascan_filter_path)
     check_exe(trnascan_path)
-    logging.info(trnascan_path)
+    logger.info(trnascan_path)
     # check_exe(trnascan_filter_path)
     check_file(trnascan_filter_path)
-    logging.info(trnascan_filter_path)
+    logger.info(trnascan_filter_path)
 
     trnascan_output_dir = create_dir(main_output_dir, "trnascan_output")
 
-    logging.info("Skip analysis if the gtf file already exists")
+    logger.info("Skip analysis if the gtf file already exists")
     output_file = os.path.join(trnascan_output_dir, "annotation.gtf")
     if os.path.exists(output_file):
         transcript_count = check_gtf_content(output_file, "transcript")
         if transcript_count > 0:
-            logging.info("Trnascan gtf file exists")
+            logger.info("Trnascan gtf file exists")
             return
     else:
-        logging.info("No gtf file, go on with the analysis")
+        logger.info("No gtf file, go on with the analysis")
 
-    logging.info("Creating list of genomic slices")
+    logger.info("Creating list of genomic slices")
     seq_region_lengths = get_seq_region_lengths(genome_file, 5000)
     slice_ids = create_slice_ids(seq_region_lengths, 1000000, 0, 5000)
 
@@ -1056,7 +1069,7 @@ def run_trnascan_regions(
         "--detail",
         "-Q",
     ]
-    logging.info("Running tRNAscan-SE")
+    logger.info("Running tRNAscan-SE")
     pool = multiprocessing.Pool(int(num_threads))
     tasks = []
     for slice_id in slice_ids:
@@ -1088,7 +1101,7 @@ def multiprocess_trnascan(
     start = slice_id[1]
     end = slice_id[2]
 
-    logging.info(
+    logger.info(
         "Processing slice to find tRNAs using tRNAscan-SE: "
         + region_name
         + ":"
@@ -1133,8 +1146,8 @@ def multiprocess_trnascan(
     trnascan_cmd[3] = trnascan_output_file_path
     trnascan_cmd[5] = trnascan_ss_output_file_path
 
-    logging.info("tRNAscan-SE command:")
-    logging.info(" ".join(trnascan_cmd))
+    logger.info("tRNAscan-SE command:")
+    logger.info(" ".join(trnascan_cmd))
     subprocess.run(trnascan_cmd)
 
     # If we have a blank output file at this point we want to stop and remove whatever files
@@ -1157,8 +1170,8 @@ def multiprocess_trnascan(
         "--prefix",
         trnascan_filter_file_prefix,
     ]
-    logging.info("tRNAscan-SE filter command:")
-    logging.info(" ".join(filter_cmd))
+    logger.info("tRNAscan-SE filter command:")
+    logger.info(" ".join(filter_cmd))
     subprocess.run(filter_cmd)
 
     create_trnascan_gtf(
@@ -1258,23 +1271,23 @@ def run_dust_regions(genome_file, dust_path, main_output_dir, num_threads):
     check_exe(dust_path)
     dust_output_dir = create_dir(main_output_dir, "dust_output")
 
-    logging.info("Skip analysis if the gtf file already exists")
+    logger.info("Skip analysis if the gtf file already exists")
     output_file = os.path.join(dust_output_dir, "annotation.gtf")
-    logging.info(output_file)
+    logger.info(output_file)
     if Path(output_file).is_file():
         transcript_count = check_gtf_content(output_file, "repeat")
         if transcript_count > 0:
-            logging.info("Dust gtf file exists")
+            logger.info("Dust gtf file exists")
             return 0
     else:
-        logging.info("No gtf file, go on with the analysis")
+        logger.info("No gtf file, go on with the analysis")
 
-    logging.info("Creating list of genomic slices")
+    logger.info("Creating list of genomic slices")
     seq_region_lengths = get_seq_region_lengths(genome_file, 5000)
     slice_ids = create_slice_ids(seq_region_lengths, 1000000, 0, 5000)
 
     generic_dust_cmd = [dust_path, "-in"]
-    logging.info("Running Dust")
+    logger.info("Running Dust")
     pool = multiprocessing.Pool(int(num_threads))
     tasks = []
     for slice_id in slice_ids:
@@ -1299,7 +1312,7 @@ def multiprocess_dust(generic_dust_cmd, slice_id, genome_file, dust_output_dir):
     start = slice_id[1]
     end = slice_id[2]
 
-    logging.info(
+    logger.info(
         "Processing slice to find low complexity regions with Dust: "
         + region_name
         + ":"
@@ -1323,7 +1336,7 @@ def multiprocess_dust(generic_dust_cmd, slice_id, genome_file, dust_output_dir):
     dust_out = open(dust_output_file_path, "w+")
     dust_cmd = generic_dust_cmd.copy()
     dust_cmd.append(region_fasta_file_path)
-    logging.info(" ".join(dust_cmd))
+    logger.info(" ".join(dust_cmd))
     subprocess.run(dust_cmd, stdout=dust_out)
     dust_out.close()
 
@@ -1369,17 +1382,17 @@ def run_trf_repeats(genome_file, trf_path, main_output_dir, num_threads):
     check_exe(trf_path)
     trf_output_dir = create_dir(main_output_dir, "trf_output")
 
-    logging.info("Skip analysis if the gtf file already exists")
+    logger.info("Skip analysis if the gtf file already exists")
     output_file = os.path.join(trf_output_dir, "annotation.gtf")
     if os.path.exists(output_file):
         transcript_count = check_gtf_content(output_file, "repeat")
         if transcript_count > 0:
-            logging.info("Trf gtf file exists")
+            logger.info("Trf gtf file exists")
             return
     else:
-        logging.info("No gtf file, go on with the analysis")
+        logger.info("No gtf file, go on with the analysis")
 
-    logging.info("Creating list of genomic slices")
+    logger.info("Creating list of genomic slices")
     seq_region_lengths = get_seq_region_lengths(genome_file, 5000)
     slice_ids = create_slice_ids(seq_region_lengths, 1000000, 0, 5000)
 
@@ -1422,7 +1435,7 @@ def run_trf_repeats(genome_file, trf_path, main_output_dir, num_threads):
         "-d",
         "-h",
     ]
-    logging.info("Running TRF")
+    logger.info("Running TRF")
     pool = multiprocessing.Pool(int(num_threads))
     tasks = []
     for slice_id in slice_ids:
@@ -1450,7 +1463,7 @@ def multiprocess_trf(
     start = slice_id[1]
     end = slice_id[2]
 
-    logging.info(
+    logger.info(
         "Processing slice to find tandem repeats with TRF: "
         + region_name
         + ":"
@@ -1475,7 +1488,7 @@ def multiprocess_trf(
     trf_output_file_path = region_fasta_file_path + trf_output_extension
     trf_cmd = generic_trf_cmd.copy()
     trf_cmd[1] = region_fasta_file_path
-    logging.info(" ".join(trf_cmd))
+    logger.info(" ".join(trf_cmd))
     subprocess.run(trf_cmd)
     create_trf_gtf(trf_output_file_path, region_results_file_path, region_name)
     os.remove(trf_output_file_path)
@@ -1544,15 +1557,15 @@ def run_cmsearch_regions(
 
     os.chdir(rfam_output_dir)
 
-    logging.info("Skip analysis if the gtf file already exists")
+    logger.info("Skip analysis if the gtf file already exists")
     output_file = os.path.join(rfam_output_dir, "annotation.gtf")
     if os.path.exists(output_file):
         transcript_count = check_gtf_content(output_file, "transcript")
         if transcript_count > 0:
-            logging.info("Cmsearch gtf file exists")
+            logger.info("Cmsearch gtf file exists")
             return
     else:
-        logging.info("No gtf file, go on with the analysis")
+        logger.info("No gtf file, go on with the analysis")
 
     rfam_dbname = "Rfam"
     rfam_user = "rfamro"
@@ -1593,7 +1606,7 @@ def run_cmsearch_regions(
     seed_descriptions = get_rfam_seed_descriptions(rfam_seeds_file_path)
     cv_models = extract_rfam_metrics(rfam_selected_models_file)
 
-    logging.info("Creating list of genomic slices")
+    logger.info("Creating list of genomic slices")
     seq_region_lengths = get_seq_region_lengths(genome_file, 5000)
     slice_ids = create_slice_ids(seq_region_lengths, 100000, 0, 5000)
 
@@ -1606,7 +1619,7 @@ def run_cmsearch_regions(
         "--cut_ga",
         "--tblout",
     ]
-    logging.info("Running Rfam")
+    logger.info("Running Rfam")
     pool = multiprocessing.Pool(int(num_threads))
     results = []
     failed_slice_ids = []
@@ -1638,7 +1651,7 @@ def run_cmsearch_regions(
     exception_files = glob.glob(rfam_output_dir + "/*.rfam.except")
     for exception_file_path in exception_files:
         exception_file_name = os.path.basename(exception_file_path)
-        logging.info("Running himem job for failed region:\n" + exception_file_path)
+        logger.info("Running himem job for failed region:\n" + exception_file_path)
         match = re.search(r"(.+)\.rs(\d+)\.re(\d+)\.", exception_file_name)
         if match:
             except_region = match.group(1)
@@ -1695,7 +1708,7 @@ def multiprocess_cmsearch(
     start = slice_id[1]
     end = slice_id[2]
 
-    logging.info(
+    logger.info(
         "Processing Rfam data using cmsearch against slice: "
         + region_name
         + ":"
@@ -1726,12 +1739,12 @@ def multiprocess_cmsearch(
     cmsearch_cmd.append(region_tblout_file_path)
     cmsearch_cmd.append(rfam_selected_models_file)
     cmsearch_cmd.append(region_fasta_file_path)
-    logging.info(" ".join(cmsearch_cmd))
+    logger.info(" ".join(cmsearch_cmd))
 
     if memory_limit is not None:
         cmsearch_cmd = prlimit_command(cmsearch_cmd, memory_limit)
 
-    logging.info(" ".join(cmsearch_cmd))
+    logger.info(" ".join(cmsearch_cmd))
 
     return_value = None
     try:
@@ -1740,7 +1753,7 @@ def multiprocess_cmsearch(
         # Note that writing to file was the only option here. If return_value was passed back, eventually it would clog the
         # tiny pipe that is used by the workers to send info back. That would mean that it would eventually just be one
         # worked running at a time
-        logging.error(
+        logger.error(
             "Issue processing the following region with cmsearch: "
             + region_name
             + " "
@@ -1748,7 +1761,7 @@ def multiprocess_cmsearch(
             + "-"
             + str(end)
         )
-        logging.error("Return value: " + str(return_value))
+        logger.error("Return value: " + str(return_value))
         exception_out = open(exception_results_file_path, "w+")
         exception_out.write(region_name + " " + str(start) + " " + str(end) + "\n")
         exception_out.close()
@@ -2175,7 +2188,7 @@ def slice_output_to_gtf(
     gtf_out = open(gtf_file_path, "w+")
     for gtf_file_path in gtf_files:
         if os.stat(gtf_file_path).st_size == 0:
-            logging.info("File is empty, will skip:\n" + gtf_file_path)
+            logger.info("File is empty, will skip:\n" + gtf_file_path)
             continue
 
         gtf_file_name = os.path.basename(gtf_file_path)
@@ -2269,7 +2282,7 @@ def slice_output_to_gtf(
                 gtf_out.write("\t".join(values))
                 line = gtf_in.readline()
             else:
-                logging.info(
+                logger.info(
                     "Feature type not recognised, will skip. Feature type: " + values[2]
                 )
                 line = gtf_in.readline()
@@ -2301,36 +2314,36 @@ def run_red(red_path, main_output_dir, genome_file):
     gtf_output_file_path = os.path.join(red_dir, "annotation.gtf")
 
     if os.path.exists(masked_genome_file):
-        logging.warning(
+        logger.warning(
             "Masked Genome file already found on the path to the Red mask output dir. Will not create a new file"
         )
         create_red_gtf(repeat_coords_file, gtf_output_file_path)
         return masked_genome_file
 
     if os.path.exists(red_genome_file):
-        logging.warning(
+        logger.warning(
             "Unmasked genome file already found on the path to the Red genome dir, will not create a sym link"
         )
 
     else:
-        logging.info(
+        logger.info(
             "Preparing to sym link the genome file to the Red genome dir. Cmd\n%s"
             % sym_link_genome_cmd
         )
         subprocess.run(["ln", "-s", genome_file, red_genome_dir])
 
     if not os.path.exists(os.path.join(red_genome_dir, genome_file_name)):
-        logging.error(
+        logger.error(
             "Could not find the genome file in the Red genome dir or sym link to the original file. Path expected:\n%s"
             % red_genome_file
         )
 
-    logging.info("Running Red, this may take some time depending on the genome size")
+    logger.info("Running Red, this may take some time depending on the genome size")
     subprocess.run(
         [red_path, "-gnm", red_genome_dir, "-msk", red_mask_dir, "-rpt", red_repeat_dir]
     )
 
-    logging.info("Completed running Red")
+    logger.info("Completed running Red")
 
     create_red_gtf(repeat_coords_file, gtf_output_file_path)
 
@@ -2398,20 +2411,20 @@ def run_genblast_align(
 
     create_dir(genblast_dir, None)
 
-    logging.info("Skip analysis if the gtf file already exists")
+    logger.info("Skip analysis if the gtf file already exists")
     output_file = os.path.join(genblast_dir, "annotation.gtf")
     if os.path.exists(output_file):
         transcript_count = check_gtf_content(output_file, "transcript")
         if transcript_count > 0:
-            logging.info("Genblast gtf file exists")
+            logger.info("Genblast gtf file exists")
             return
     else:
-        logging.info("No gtf file, go on with the analysis")
+        logger.info("No gtf file, go on with the analysis")
 
     genblast_output_file = os.path.join(genblast_dir, "genblast")
 
     asnb_file = masked_genome_file + ".asnb"
-    logging.info("ASNB file: %s" % asnb_file)
+    logger.info("ASNB file: %s" % asnb_file)
 
     if not os.path.exists("alignscore.txt"):
         subprocess.run(
@@ -2431,7 +2444,7 @@ def run_genblast_align(
     if not os.path.exists(asnb_file):
         run_convert2blastmask(convert2blastmask_path, masked_genome_file, asnb_file)
     else:
-        logging.info("Found an existing asnb, so will skip convert2blastmask")
+        logger.info("Found an existing asnb, so will skip convert2blastmask")
 
     if not os.path.exists(asnb_file):
         raise IOError("asnb file does not exist: %s" % asnb_file)
@@ -2455,8 +2468,8 @@ def run_genblast_align(
     pool.close()
     pool.join()
 
-    logging.info("Completed running GenBlast")
-    logging.info("Combining output into single GTF")
+    logger.info("Completed running GenBlast")
+    logger.info("Combining output into single GTF")
     generate_genblast_gtf(genblast_dir)
 
 
@@ -2470,7 +2483,7 @@ def multiprocess_genblast(
 
     batch_num = os.path.splitext(batched_protein_file)[0]
     batch_dir = os.path.dirname(batched_protein_file)
-    logging.info("Running GenBlast on " + batched_protein_file + ":")
+    logger.info("Running GenBlast on " + batched_protein_file + ":")
 
     genblast_cmd = [
         genblast_path,
@@ -2509,11 +2522,11 @@ def multiprocess_genblast(
         batched_protein_file,
     ]
 
-    logging.info(" ".join(genblast_cmd))
+    logger.info(" ".join(genblast_cmd))
     try:
         subprocess.run(genblast_cmd, timeout=genblast_timeout_secs)
     except subprocess.TimeoutExpired:
-        logging.error("Timeout reached for file:\n" + batched_protein_file)
+        logger.error("Timeout reached for file:\n" + batched_protein_file)
         subprocess.run(["touch", (batched_protein_file + ".except")])
 
     files_to_delete = glob.glob(batched_protein_file + "*msk.blast*")
@@ -2659,7 +2672,7 @@ def split_protein_file(protein_file, protein_output_dir, batch_size):
 def run_convert2blastmask(convert2blastmask_path, masked_genome_file, asnb_file):
 
     asnb_file = masked_genome_file + ".asnb"
-    logging.info("Running convert2blastmask prior to GenBlast:")
+    logger.info("Running convert2blastmask prior to GenBlast:")
     cmd = [
         convert2blastmask_path,
         "-in",
@@ -2674,14 +2687,14 @@ def run_convert2blastmask(convert2blastmask_path, masked_genome_file, asnb_file)
         "-out",
         asnb_file,
     ]
-    logging.info(" ".join(cmd))
+    logger.info(" ".join(cmd))
     subprocess.run(cmd)
-    logging.info("Completed running convert2blastmask")
+    logger.info("Completed running convert2blastmask")
 
 
 def run_makeblastdb(makeblastdb_path, masked_genome_file, asnb_file):
 
-    logging.info("Running makeblastdb prior to GenBlast")
+    logger.info("Running makeblastdb prior to GenBlast")
     subprocess.run(
         [
             makeblastdb_path,
@@ -2696,7 +2709,7 @@ def run_makeblastdb(makeblastdb_path, masked_genome_file, asnb_file):
             "10000000000",
         ]
     )
-    logging.info("Completed running makeblastdb")
+    logger.info("Completed running makeblastdb")
 
 
 def run_trimming(
@@ -2716,7 +2729,7 @@ def run_trimming(
     fastq_file_list = create_paired_paths(fastq_file_list)
 
     for fastq_file_path in fastq_file_list:
-        logging.info("fastaq file path" + fastq_file_path)
+        logger.info("fastaq file path" + fastq_file_path)
 
     generic_trim_galore_cmd = [
         trim_galore_path,
@@ -2741,9 +2754,7 @@ def run_trimming(
         )
         if delete_pre_trim_fastq:
             for file_path in fastq_files:
-                logging.info(
-                    "Removing original fastq file post trimming:\n" + file_path
-                )
+                logger.info("Removing original fastq file post trimming:\n" + file_path)
                 subprocess.run(["rm", file_path])
 
     pool.close()
@@ -2751,10 +2762,10 @@ def run_trimming(
 
     trimmed_fastq_list = glob.glob(os.path.join(trim_dir, "*.fq.gz"))
     for trimmed_fastq_path in trimmed_fastq_list:
-        logging.info("Trimmed file path:\n" + trimmed_fastq_path)
+        logger.info("Trimmed file path:\n" + trimmed_fastq_path)
         sub_patterns = r"|".join(("_val_1.fq", "_val_2.fq", "_trimmed.fq"))
         updated_file_path = re.sub(sub_patterns, ".fq", trimmed_fastq_path)
-        logging.info("Updated file path:\n" + updated_file_path)
+        logger.info("Updated file path:\n" + updated_file_path)
         subprocess.run(["mv", trimmed_fastq_path, updated_file_path])
 
         files_to_delete_list = []
@@ -2780,8 +2791,8 @@ def multiprocess_trim_galore(generic_trim_galore_cmd, fastq_files, trim_dir):
     if fastq_file_pair:
         trim_galore_cmd.append(fastq_file_pair)
 
-    logging.info("Running Trim Galore with the following command:")
-    logging.info(" ".join(trim_galore_cmd))
+    logger.info("Running Trim Galore with the following command:")
+    logger.info(" ".join(trim_galore_cmd))
     subprocess.run(trim_galore_cmd)
 
 
@@ -2813,15 +2824,15 @@ def run_star_align(
 
     star_dir = create_dir(main_output_dir, "star_output")
 
-    logging.info("Skip analysis if the final log file already exists")
+    logger.info("Skip analysis if the final log file already exists")
     log_final_out = Path(os.path.join(star_dir, "Log.final.out"))
     log_out = Path(os.path.join(star_dir, "Log.out"))
     log_progress_out = Path(os.path.join(star_dir, "Log.progress.out"))
     if log_final_out.is_file() and log_out.is_file() and log_progress_out.is_file():
-        logging.info("Star gtf file exists")
+        logger.info("Star gtf file exists")
         return
     else:
-        logging.info("No log files, go on with the analysis")
+        logger.info("No log files, go on with the analysis")
 
     star_tmp_dir = os.path.join(star_dir, "tmp")
     if os.path.exists(star_tmp_dir):
@@ -2851,11 +2862,11 @@ def run_star_align(
                 and os.path.exists(fastq_file + ".sub")
                 and os.path.exists(fastq_file_pair + ".sub")
             ):
-                logging.info(
+                logger.info(
                     "Found an existing .sub files on the fastq path for both members of the pair, will use those instead of subsampling again. Files:"
                 )
-                logging.info(fastq_file + ".sub")
-                logging.info(fastq_file_pair + ".sub")
+                logger.info(fastq_file + ".sub")
+                logger.info(fastq_file_pair + ".sub")
             elif fastq_file_pair:
                 pool.apply_async(
                     run_subsample_script,
@@ -2866,10 +2877,10 @@ def run_star_align(
                     ),
                 )
             elif os.path.exists(fastq_file + ".sub"):
-                logging.info(
+                logger.info(
                     "Found an existing .sub file on the fastq path, will use that instead. File:"
                 )
-                logging.info(fastq_file + ".sub")
+                logger.info(fastq_file + ".sub")
             else:
                 pool.apply_async(
                     run_subsample_script,
@@ -2891,7 +2902,7 @@ def run_star_align(
         )
 
     if not os.path.exists(star_index_file):
-        logging.info("Did not find an index file for Star. Will create now")
+        logger.info("Did not find an index file for Star. Will create now")
         seq_region_lengths = get_seq_region_lengths(genome_file, 0)
         genome_size = sum(seq_region_lengths.values())
         index_bases = min(14, math.floor((math.log(genome_size, 2) / 2) - 1))
@@ -2918,9 +2929,9 @@ def run_star_align(
             "The index file does not exist. Expected path:\n%s" % star_index_file
         )
 
-    logging.info("Running Star on the files in the fastq dir")
+    logger.info("Running Star on the files in the fastq dir")
     for fastq_file_path in fastq_file_list:
-        logging.info(fastq_file_path)
+        logger.info(fastq_file_path)
         fastq_file_name = os.path.basename(fastq_file_path)
         check_compression = re.search(r".gz$", fastq_file_name)
 
@@ -2930,13 +2941,13 @@ def run_star_align(
         # uniquely. Also there should be code checking the return on STAR anyway. So later when this is being
         # cleaned up to have proper tests, need to decide on the best implementation
         if os.path.exists(star_tmp_dir):
-            logging.error(
+            logger.error(
                 "Found an existing tmp dir, implies potential failure on previous file. Removing tmp dir"
             )
             try:
                 shutil.rmtree(star_tmp_dir)
             except OSError as e:
-                logging.error("Error: %s - %s." % (e.filename, e.strerror))
+                logger.error("Error: %s - %s." % (e.filename, e.strerror))
 
         sam_file_path = os.path.join(star_dir, (fastq_file_name + ".sam"))
         junctions_file_path = os.path.join(star_dir, (fastq_file_name + ".sj.tab"))
@@ -2950,12 +2961,12 @@ def run_star_align(
             os.path.isfile(bam_sort_file_path)
             and not os.stat(bam_sort_file_path).st_size == 0
         ):
-            logging.info(
+            logger.info(
                 "Found an existing bam file for the fastq file, presuming the file has been processed, will skip"
             )
             continue
 
-        logging.info("Processing %s" % fastq_file_path)
+        logger.info("Processing %s" % fastq_file_path)
         #    star_command = [star_path,'--outFilterIntronMotifs','RemoveNoncanonicalUnannotated','--outSAMstrandField','intronMotif','--runThreadN',str(num_threads),'--twopassMode','Basic','--runMode','alignReads','--genomeDir',star_dir,'--readFilesIn',fastq_file_path,'--outFileNamePrefix',(star_dir + '/'),'--outTmpDir',star_tmp_dir,'--outSAMtype','SAM','--alignIntronMax',str(max_intron_length),'--outSJfilterIntronMaxVsReadN','5000','10000','25000','40000','50000','50000','50000','50000','50000','100000']
 
         star_command = [
@@ -2995,8 +3006,8 @@ def run_star_align(
             ["mv", os.path.join(star_dir, "SJ.out.tab"), junctions_file_path]
         )
 
-        logging.info("Converting samfile into sorted bam file. Bam file:")
-        logging.info(bam_sort_file_path)
+        logger.info("Converting samfile into sorted bam file. Bam file:")
+        logger.info(bam_sort_file_path)
         subprocess.run(
             [
                 "samtools",
@@ -3011,10 +3022,10 @@ def run_star_align(
             ]
         )
 
-        logging.info("Removing sam file")
+        logger.info("Removing sam file")
         subprocess.run(["rm", sam_file_path])
 
-    logging.info("Completed running STAR")
+    logger.info("Completed running STAR")
 
 
 def run_subsample_script(fastq_file, fastq_file_pair, subsample_script_path):
@@ -3050,26 +3061,26 @@ def check_for_fastq_subsamples(fastq_file_list):
 
         # This bit will replace the list entry with a string, don't need a list after this function for each pair/file
         if os.path.exists(subsample_file):
-            logging.info(
+            logger.info(
                 "Found a subsampled file extension, will use that instead of the original file. Path:"
             )
-            logging.info(subsample_file)
+            logger.info(subsample_file)
             fastq_file_list[idx] = subsample_file
         else:
             fastq_file_list[idx] = fastq_file
 
         # This bit just concats the paired file (or subsampled paired file) if it exists
         if os.path.exists(subsample_file_pair):
-            logging.info(
+            logger.info(
                 "Found a subsampled paired file extension, will use that instead of the original file. Path:"
             )
-            logging.info(subsample_file_pair)
+            logger.info(subsample_file_pair)
             fastq_file_list[idx] = subsample_file + "," + subsample_file_pair
         elif fastq_file_pair:
             fastq_file_list[idx] = fastq_file + "," + fastq_file_pair
 
-        logging.info("Entry at current index:")
-        logging.info(fastq_file_list[idx])
+        logger.info("Entry at current index:")
+        logger.info(fastq_file_list[idx])
 
     return fastq_file_list
 
@@ -3096,15 +3107,15 @@ def run_minimap2_align(
 
     minimap2_output_dir = create_dir(main_output_dir, "minimap2_output")
 
-    logging.info("Skip analysis if the gtf file already exists")
+    logger.info("Skip analysis if the gtf file already exists")
     output_file = os.path.join(minimap2_output_dir, "annotation.gtf")
     if os.path.exists(output_file):
         transcript_count = check_gtf_content(output_file, "transcript")
         if transcript_count > 0:
-            logging.info("Minimap2 gtf file exists")
+            logger.info("Minimap2 gtf file exists")
             return
     else:
-        logging.info("No gtf file, go on with the analysis")
+        logger.info("No gtf file, go on with the analysis")
 
     genome_file_name = os.path.basename(genome_file)
     genome_file_index = genome_file_name + ".mmi"
@@ -3129,7 +3140,7 @@ def run_minimap2_align(
     #    raise IndexError('The list of fastq files is empty. Fastq dir:\n%s' % long_read_fastq_dir)
 
     if not os.path.exists(minimap2_index_file):
-        logging.info("Did not find an index file for minimap2. Will create now")
+        logger.info("Did not find an index file for minimap2. Will create now")
         subprocess.run(
             [
                 minimap2_path,
@@ -3147,13 +3158,13 @@ def run_minimap2_align(
             % minimap2_index_file
         )
 
-    logging.info("Running minimap2 on the files in the long read fastq dir")
+    logger.info("Running minimap2 on the files in the long read fastq dir")
     for fastq_file_path in fastq_file_list:
         fastq_file_name = os.path.basename(fastq_file_path)
         sam_file = os.path.join(minimap2_output_dir, (fastq_file_name + ".sam"))
         bed_file = os.path.join(minimap2_output_dir, (fastq_file_name + ".bed"))
         bed_file_out = open(bed_file, "w+")
-        logging.info("Processing %s" % fastq_file)
+        logger.info("Processing %s" % fastq_file)
         subprocess.run(
             [
                 minimap2_path,
@@ -3173,13 +3184,13 @@ def run_minimap2_align(
                 sam_file,
             ]
         )
-        logging.info("Creating bed file from SAM")
+        logger.info("Creating bed file from SAM")
         subprocess.run([paftools_path, "splice2bed", sam_file], stdout=bed_file_out)
         bed_file_out.close()
 
     bed_to_gtf(minimap2_output_dir)
 
-    logging.info("Completed running minimap2")
+    logger.info("Completed running minimap2")
 
 
 def bed_to_gtf(minimap2_output_dir):
@@ -3189,8 +3200,8 @@ def bed_to_gtf(minimap2_output_dir):
     exons_dict = {}
     gene_id = 1
     for bed_file in glob.glob(minimap2_output_dir + "/*.bed"):
-        logging.info("Converting bed to GTF:")
-        logging.info(bed_file)
+        logger.info("Converting bed to GTF:")
+        logger.info(bed_file)
         bed_in = open(bed_file)
         bed_lines = bed_in.readlines()
         for line in bed_lines:
@@ -3269,8 +3280,8 @@ def bed_to_gff(input_dir, hints_file):
     gff_out = open(hints_file, "w+")
     exons_dict = {}
     for bed_file in glob.glob(input_dir + "/*.bed"):
-        logging.info("Processing file for hints:")
-        logging.info(bed_file)
+        logger.info("Processing file for hints:")
+        logger.info(bed_file)
         bed_in = open(bed_file)
         bed_lines = bed_in.readlines()
         for line in bed_lines:
@@ -3333,9 +3344,7 @@ def bed_to_exons(block_sizes, block_starts, offset):
         block_end = block_start + int(block_sizes[i]) - 1
 
         if block_end < block_start:
-            logging.warning(
-                "Warning: block end is less than block start, skipping exon"
-            )
+            logger.warning("Warning: block end is less than block start, skipping exon")
             continue
 
         exon_coords = [str(block_start), str(block_end)]
@@ -3355,7 +3364,7 @@ def check_transcriptomic_output(main_output_dir):
             main_output_dir, transcriptomic_dir, "annotation.gtf"
         )
         if not os.path.exists(full_file_path):
-            logging.warning(
+            logger.warning(
                 "Warning, no annotation.gtf found for "
                 + transcriptomic_dir
                 + ". This might be fine, e.g. no long read data were provided"
@@ -3363,7 +3372,7 @@ def check_transcriptomic_output(main_output_dir):
             continue
         num_lines = sum(1 for line in open(full_file_path))
         total_lines = total_lines + num_lines
-        logging.info(
+        logger.info(
             "For "
             + transcriptomic_dir
             + " found a total of "
@@ -3383,7 +3392,7 @@ def check_transcriptomic_output(main_output_dir):
         )
 
     else:
-        logging.info(
+        logger.info(
             "Found "
             + str(total_lines)
             + " total lines across the transcriptomic files. Checks passed"
@@ -3513,7 +3522,7 @@ def run_augustus_predict(
     minimap2_output_dir = os.path.join(main_output_dir, "minimap2_output")
 
     if os.path.exists(star_dir):
-        logging.info("Found a Star output dir, generating hints from any .sj.tab files")
+        logger.info("Found a Star output dir, generating hints from any .sj.tab files")
         generate_hints(
             bam2hints_path,
             bam2wig_path,
@@ -3633,7 +3642,7 @@ def multiprocess_augustus_hints(
     bam2hints_path, bam2wig_path, wig2hints_path, bam_file, augustus_hints_dir
 ):
     bam_file_name = os.path.basename(bam_file)
-    logging.info("Processing " + bam_file_name + " for Augustus hints")
+    logger.info("Processing " + bam_file_name + " for Augustus hints")
 
     bam2hints_file_name = bam_file_name + ".hints.gff"
     bam2hints_file_path = os.path.join(augustus_hints_dir, bam2hints_file_name)
@@ -3643,7 +3652,7 @@ def multiprocess_augustus_hints(
         ("--out=" + bam2hints_file_path),
         "--maxintronlen=100000",
     ]
-    logging.info("bam2hints command:\n" + " ".join(bam2hints_cmd))
+    logger.info("bam2hints command:\n" + " ".join(bam2hints_cmd))
     subprocess.run(bam2hints_cmd)
 
 
@@ -3756,22 +3765,22 @@ def run_stringtie_assemble(
 
     stringtie_dir = create_dir(main_output_dir, "stringtie_output")
 
-    logging.info("Skip analysis if the gtf file already exists")
+    logger.info("Skip analysis if the gtf file already exists")
     output_file = os.path.join(stringtie_dir, "annotation.gtf")
     if os.path.exists(output_file):
         transcript_count = check_gtf_content(output_file, "transcript")
         if transcript_count > 0:
-            logging.info("Stringtie gtf file exists")
+            logger.info("Stringtie gtf file exists")
             return
     else:
-        logging.info("No gtf file, go on with the analysis")
+        logger.info("No gtf file, go on with the analysis")
 
     stringtie_merge_input_file = os.path.join(stringtie_dir, "stringtie_assemblies.txt")
     stringtie_merge_output_file = os.path.join(stringtie_dir, "annotation.gtf")
     star_dir = os.path.join(main_output_dir, "star_output")
 
     if os.path.exists(star_dir):
-        logging.info("Found a Star output dir, will load sam file")
+        logger.info("Found a Star output dir, will load sam file")
 
     sorted_bam_files = []
     for bam_file in glob.glob(star_dir + "/*.bam"):
@@ -3791,13 +3800,13 @@ def run_stringtie_assemble(
         transcript_file_path = os.path.join(stringtie_dir, transcript_file_name)
 
         if os.path.exists(transcript_file_path):
-            logging.info(
+            logger.info(
                 "Found an existing stringtie gtf file, will not overwrite. File found:"
             )
-            logging.info(transcript_file_path)
+            logger.info(transcript_file_path)
         else:
-            logging.info("Running Stringtie on: " + sorted_bam_file_name)
-            logging.info("Writing output to: " + transcript_file_path)
+            logger.info("Running Stringtie on: " + sorted_bam_file_name)
+            logger.info("Writing output to: " + transcript_file_path)
             subprocess.run(
                 [
                     stringtie_path,
@@ -3813,23 +3822,23 @@ def run_stringtie_assemble(
             )
 
     # Now need to merge
-    logging.info("Creating Stringtie merge input file: " + stringtie_merge_input_file)
+    logger.info("Creating Stringtie merge input file: " + stringtie_merge_input_file)
 
     # Now need to merge
-    logging.info("Creating Stringtie merge input file: " + stringtie_merge_input_file)
+    logger.info("Creating Stringtie merge input file: " + stringtie_merge_input_file)
     gtf_list_out = open(stringtie_merge_input_file, "w+")
     for gtf_file in glob.glob(stringtie_dir + "/*.stringtie.gtf"):
         transcript_count = check_gtf_content(gtf_file, "transcript")
         if transcript_count > 0:
             gtf_list_out.write(gtf_file + "\n")
         else:
-            logging.warning(
+            logger.warning(
                 "Warning, skipping file with no transcripts. Path:\n" + gtf_file
             )
     gtf_list_out.close()
 
-    logging.info("Merging Stringtie results. Writing to the following file:")
-    logging.info(stringtie_merge_output_file)
+    logger.info("Merging Stringtie results. Writing to the following file:")
+    logger.info(stringtie_merge_output_file)
     subprocess.run(
         [
             stringtie_path,
@@ -3853,15 +3862,15 @@ def run_scallop_assemble(scallop_path, stringtie_path, main_output_dir):
 
     scallop_dir = create_dir(main_output_dir, "scallop_output")
 
-    logging.info("Skip analysis if the gtf file already exists")
+    logger.info("Skip analysis if the gtf file already exists")
     output_file = os.path.join(scallop_dir, "annotation.gtf")
     if os.path.exists(output_file):
         transcript_count = check_gtf_content(output_file, "transcript")
         if transcript_count > 0:
-            logging.info("Scallop gtf file exists")
+            logger.info("Scallop gtf file exists")
             return
     else:
-        logging.info("No gtf file, go on with the analysis")
+        logger.info("No gtf file, go on with the analysis")
 
     stringtie_merge_input_file = os.path.join(scallop_dir, "scallop_assemblies.txt")
     stringtie_merge_output_file = os.path.join(scallop_dir, "annotation.gtf")
@@ -3869,7 +3878,7 @@ def run_scallop_assemble(scallop_path, stringtie_path, main_output_dir):
     memory_limit = 40 * 1024**3
 
     if os.path.exists(star_dir):
-        logging.info("Found a Star output dir, will load bam files")
+        logger.info("Found a Star output dir, will load bam files")
 
     sorted_bam_files = []
     for bam_file in glob.glob(star_dir + "/*.bam"):
@@ -3889,13 +3898,13 @@ def run_scallop_assemble(scallop_path, stringtie_path, main_output_dir):
         transcript_file_path = os.path.join(scallop_dir, transcript_file_name)
 
         if os.path.exists(transcript_file_path):
-            logging.info(
+            logger.info(
                 "Found an existing scallop gtf file, will not overwrite. File found:"
             )
-            logging.info(transcript_file_path)
+            logger.info(transcript_file_path)
         else:
-            logging.info("Running Scallop on: " + sorted_bam_file_name)
-            logging.info("Writing output to: " + transcript_file_path)
+            logger.info("Running Scallop on: " + sorted_bam_file_name)
+            logger.info("Writing output to: " + transcript_file_path)
             scallop_cmd = [
                 scallop_path,
                 "-i",
@@ -3912,13 +3921,13 @@ def run_scallop_assemble(scallop_path, stringtie_path, main_output_dir):
             try:
                 return_value = subprocess.check_output(scallop_cmd)
             except subprocess.CalledProcessError as ex:
-                logging.error("Issue processing the following region with scallop")
-                logging.error("Return value: " + str(return_value))
+                logger.error("Issue processing the following region with scallop")
+                logger.error("Return value: " + str(return_value))
 
     #      subprocess.run([scallop_path,'-i',sorted_bam_file,'-o',transcript_file_path,'--min_flank_length','10'])
 
     # Now need to merge
-    logging.info("Creating Stringtie merge input file: " + stringtie_merge_input_file)
+    logger.info("Creating Stringtie merge input file: " + stringtie_merge_input_file)
 
     gtf_list_out = open(stringtie_merge_input_file, "w+")
     for gtf_file in glob.glob(scallop_dir + "/*.scallop.gtf"):
@@ -3926,13 +3935,13 @@ def run_scallop_assemble(scallop_path, stringtie_path, main_output_dir):
         if transcript_count > 0:
             gtf_list_out.write(gtf_file + "\n")
         else:
-            logging.warning(
+            logger.warning(
                 "Warning, skipping file with no transcripts. Path:\n" + gtf_file
             )
     gtf_list_out.close()
 
-    logging.info("Merging Scallop results. Writing to the following file:")
-    logging.info(stringtie_merge_output_file)
+    logger.info("Merging Scallop results. Writing to the following file:")
+    logger.info(stringtie_merge_output_file)
     subprocess.run(
         [
             stringtie_path,
@@ -3945,7 +3954,7 @@ def run_scallop_assemble(scallop_path, stringtie_path, main_output_dir):
 
 
 def check_gtf_content(gtf_file, content_obj):
-    logging.info("check gtf transcript function")
+    logger.info("check gtf transcript function")
     # This just checks how many transcript lines are in a GTF
     transcript_count = 0
     gtf_in = open(gtf_file)
@@ -3959,7 +3968,7 @@ def check_gtf_content(gtf_file, content_obj):
             transcript_count += 1
         line = gtf_in.readline()
     gtf_in.close()
-    logging.info(transcript_count)
+    logger.info(transcript_count)
     return transcript_count
 
 
@@ -4103,10 +4112,10 @@ def split_genome(genome_file, target_dir, min_seq_length):
             file_out.close()
 
         else:
-            logging.info(
+            logger.info(
                 "Found an existing split file, so will not overwrite. File found:"
             )
-            logging.info(file_out_name)
+            logger.info(file_out_name)
 
     file_in.close()
 
@@ -4150,9 +4159,9 @@ def run_finalise_geneset(
 ):
 
     if validation_type is None:
-        logging.info("Setting validation type to relaxed")
+        logger.info("Setting validation type to relaxed")
     else:
-        logging.info("Setting validation type to " + validation_type)
+        logger.info("Setting validation type to " + validation_type)
 
     final_annotation_dir = create_dir(main_output_dir, "annotation_output")
     region_annotation_dir = create_dir(final_annotation_dir, "initial_region_gtfs")
@@ -4206,7 +4215,7 @@ def run_finalise_geneset(
     ]:
 
         if not os.path.exists(transcriptomic_file):
-            logging.info(
+            logger.info(
                 "No annotation.gtf file found in " + transcriptomic_file + ", skipping"
             )
             continue
@@ -4263,7 +4272,7 @@ def run_finalise_geneset(
         )
 
         if os.path.exists(transcriptomic_annotation_raw):
-            logging.info("Finalising transcriptomic data for: " + seq_region_name)
+            logger.info("Finalising transcriptomic data for: " + seq_region_name)
             transcriptomic_annotation_select = re.sub(
                 "_raw.gtf", "_sel.gtf", transcriptomic_annotation_raw
             )
@@ -4284,7 +4293,7 @@ def run_finalise_geneset(
             pool.apply_async(multiprocess_finalise_geneset, args=(cmd,))
 
         if os.path.exists(busco_annotation_raw):
-            logging.info("Finalising BUSCO data for: " + seq_region_name)
+            logger.info("Finalising BUSCO data for: " + seq_region_name)
             busco_annotation_select = re.sub(
                 "_raw.gtf", "_sel.gtf", busco_annotation_raw
             )
@@ -4305,7 +4314,7 @@ def run_finalise_geneset(
             pool.apply_async(multiprocess_finalise_geneset, args=(cmd,))
 
         if os.path.exists(protein_annotation_raw):
-            logging.info("Finalising protein data for: " + seq_region_name)
+            logger.info("Finalising protein data for: " + seq_region_name)
             protein_annotation_select = re.sub(
                 "_raw.gtf", "_sel.gtf", protein_annotation_raw
             )
@@ -4412,7 +4421,7 @@ def run_finalise_geneset(
     )
     cleaned_utr_gtf_file = os.path.join(final_annotation_dir, ("annotation.gtf"))
 
-    logging.info("Cleaning initial set")
+    logger.info("Cleaning initial set")
     cleaning_cmd = [
         "perl",
         clean_geneset_script,
@@ -4423,7 +4432,7 @@ def run_finalise_geneset(
         "-output_gtf_file",
         cleaned_initial_gtf_file,
     ]
-    logging.info(" ".join(cleaning_cmd))
+    logger.info(" ".join(cleaning_cmd))
     subprocess.run(cleaning_cmd)
 
     # Clean UTRs
@@ -4470,7 +4479,7 @@ def run_finalise_geneset(
         ]
     )
 
-    logging.info("Dumping transcript and translation sequences")
+    logger.info("Dumping transcript and translation sequences")
     dumping_cmd = [
         "perl",
         gtf_to_seq_script,
@@ -4479,10 +4488,10 @@ def run_finalise_geneset(
         "-gtf_file",
         cleaned_utr_gtf_file,
     ]
-    logging.info(" ".join(dumping_cmd))
+    logger.info(" ".join(dumping_cmd))
     subprocess.run(dumping_cmd)
 
-    logging.info("Finished creating gene set")
+    logger.info("Finished creating gene set")
 
 
 def validate_coding_transcripts(
@@ -4495,7 +4504,7 @@ def validate_coding_transcripts(
     num_threads,
 ):
 
-    logging.info("Running CDS validation with RNAsamba and CPC2")
+    logger.info("Running CDS validation with RNAsamba and CPC2")
     rnasamba_weights = "/nfs/production/flicek/ensembl/genebuild/genebuild_virtual_user/rnasamba_data/full_length_weights.hdf5"
     rnasamba_output_path = os.path.join(validation_dir, "rnasamba.tsv.txt")
     cpc2_output_path = os.path.join(validation_dir, "cpc2.tsv")
@@ -4512,7 +4521,7 @@ def validate_coding_transcripts(
         cdna_file,
         rnasamba_weights,
     ]
-    logging.info(" ".join(rnasamba_cmd))
+    logger.info(" ".join(rnasamba_cmd))
     subprocess.run(rnasamba_cmd)
     cpc2_volume = validation_dir + "/:/app:rw"
     cpc2_cmd = [
@@ -4529,14 +4538,14 @@ def validate_coding_transcripts(
         "-o",
         cpc2_output_path,
     ]
-    logging.info(" ".join(cpc2_cmd))
+    logger.info(" ".join(cpc2_cmd))
     subprocess.run(cpc2_cmd)
     cpc2_output_path = cpc2_output_path + ".txt"
 
     check_file(rnasamba_output_path)
     check_file(cpc2_output_path)
 
-    logging.info("diamond validation")
+    logger.info("diamond validation")
     diamond_results = None
     if diamond_validation_db is not None:
         diamond_output_dir = create_dir(validation_dir, "diamond_output")
@@ -4545,11 +4554,11 @@ def validate_coding_transcripts(
         )
         diamond_results = read_diamond_results(diamond_output_dir)
 
-    logging.info("read results")
+    logger.info("read results")
     rnasamba_results = read_rnasamba_results(rnasamba_output_path)
     cpc2_results = read_cpc2_results(cpc2_output_path)
     combined_results = combine_results(rnasamba_results, cpc2_results, diamond_results)
-    logging.info("read gtf genes")
+    logger.info("read gtf genes")
     parsed_gtf_genes = read_gtf_genes(gtf_file)
     updated_gtf_lines = update_gtf_genes(
         parsed_gtf_genes, combined_results, validation_type
@@ -4587,7 +4596,7 @@ def multiprocess_diamond(
     batch_num = os.path.splitext(batched_protein_file)[0]
     batch_dir = os.path.dirname(batched_protein_file)
     diamond_output_file = batched_protein_file + ".dmdout"
-    logging.info("Running diamond on " + batched_protein_file + ":")
+    logger.info("Running diamond on " + batched_protein_file + ":")
 
     diamond_cmd = [
         "diamond",
@@ -4600,7 +4609,7 @@ def multiprocess_diamond(
         diamond_output_file,
     ]
 
-    logging.info(" ".join(diamond_cmd))
+    logger.info(" ".join(diamond_cmd))
     subprocess.run(diamond_cmd)
     subprocess.run(["mv", diamond_output_file, diamond_output_dir])
 
@@ -4953,7 +4962,7 @@ def merge_finalise_output_files(
     cdna_out = open(merged_cdna_file, "w+")
     amino_acid_out = open(merged_amino_acid_file, "w+")
     for gtf_file in gtf_files:
-        logging.info("GTF file: " + gtf_file)
+        logger.info("GTF file: " + gtf_file)
         cdna_seq_index = {}
         amino_acid_seq_index = {}
         cdna_file = gtf_file + ".cdna"
@@ -5118,7 +5127,7 @@ def seq_region_names(genome_file):
         if match:
             region_name = match.group(1)
             if region_name == "MT":
-                logging.info("Skipping region named MT")
+                logger.info("Skipping region named MT")
                 line = file_in.readline()
                 continue
             else:
@@ -5187,10 +5196,10 @@ def create_paired_paths(fastq_file_paths):
     for path in fastq_file_paths:
         match = re.search(r"(.+)_\d+\.(fastq|fq)", path)
         if not match:
-            logging.error(
+            logger.error(
                 "Could not find _1 or _2 at the end of the prefix for file. Assuming file is not paired:"
             )
-            logging.error(path)
+            logger.error(path)
             final_list.append([path])
             continue
 
@@ -5240,22 +5249,6 @@ def coallate_results(main_output_dir):
         if os.path.exists(results_path):
             cpy_cmd = ["cp", results_path, copy_path]
             subprocess.run(cpy_cmd)
-
-
-def _configure_logging(work_dir):
-    filename = os.path.join(work_dir, "AnnoLogFile.log")
-    print("FILENAME", filename)
-    # Remove all handlers associated with the root logger object.
-    # for handler in logging.root.handlers[:]:
-    #    logging.root.removeHandler(handler)
-    logging.basicConfig(
-        filename=filename,
-        filemode="w",
-        format="%(asctime)s,%(msecs)d %(name)s - %(levelname)s - %(message)s",
-        datefmt="%H:%M:%S",
-        level=logging.DEBUG,
-    )
-    logging.warning("This will get logged to a file")
 
 
 if __name__ == "__main__":
@@ -5579,15 +5572,21 @@ if __name__ == "__main__":
         work_dir = os.getcwd()
         # work_dir=glob.glob(work_dir)
 
-    _configure_logging(work_dir)
-    logging.info("Work dir is: %s" % work_dir)
+    # create file handler and add to logger
+    log_file_path = pathlib.Path(work_dir) / "ensembl_anno.log"
+    file_handler = logging.FileHandler(log_file_path, mode="a+")
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(logging_formatter_time_message)
+    logger.addHandler(file_handler)
+
+    logger.info(f"work directory: {work_dir}")
 
     if not os.path.exists(work_dir):
-        logging.info("Work dir does not exist, will create")
+        logger.info("Work dir does not exist, will create")
         create_dir(work_dir, None)
 
     if num_threads == 1:
-        logging.info("Thread count is set to the default value 1; this might be slow.")
+        logger.info("Thread count is set to the default value 1; this might be slow.")
 
     # If the run_full_annotation flag is set then we want to set a standardised set of analyses
     if run_full_annotation:
@@ -5630,29 +5629,29 @@ if __name__ == "__main__":
     # Collect a list of seq region names, most useful for multiprocessing regions
     seq_region_names = seq_region_names(genome_file)
     for i in seq_region_names:
-        logging.info(i)
+        logger.info(i)
 
     #################################
     # Repeat analyses
     #################################
     if run_masking:
-        logging.info("Running masking via Red")
+        logger.info("Running masking via Red")
         masked_genome_file = run_red(red_path, work_dir, genome_file)
-        logging.info("Masked genome file: " + masked_genome_file)
+        logger.info("Masked genome file: " + masked_genome_file)
 
     else:
-        logging.info("Not running masking, presuming the genome file is softmasked")
+        logger.info("Not running masking, presuming the genome file is softmasked")
 
     if run_dust:
-        logging.info("Annotating low complexity regions")
+        logger.info("Annotating low complexity regions")
         run_dust_regions(genome_file, dust_path, work_dir, num_threads)
 
     if run_trf:
-        logging.info("Annotating tandem repeats")
+        logger.info("Annotating tandem repeats")
         run_trf_repeats(genome_file, trf_path, work_dir, num_threads)
 
     if run_repeatmasker:
-        logging.info("Annotating repeats with RepeatMasker")
+        logger.info("Annotating repeats with RepeatMasker")
         run_repeatmasker_regions(
             genome_file, repeatmasker_path, library, species, work_dir, num_threads
         )
@@ -5661,11 +5660,11 @@ if __name__ == "__main__":
     # Simple feature analyses
     #################################
     if run_cpg:
-        logging.info("Annotating CpG islands")
+        logger.info("Annotating CpG islands")
         run_cpg_regions(genome_file, cpg_path, work_dir, num_threads)
 
     if run_eponine:
-        logging.info("Running Eponine to find transcription start sites")
+        logger.info("Running Eponine to find transcription start sites")
         run_eponine_regions(genome_file, java_path, eponine_path, work_dir, num_threads)
 
     #################################
@@ -5673,13 +5672,13 @@ if __name__ == "__main__":
     #################################
     # Search Rfam with cmsearch
     if run_cmsearch:
-        logging.info("Annotating sncRNAs")
+        logger.info("Annotating sncRNAs")
         run_cmsearch_regions(
             genome_file, None, None, None, rfam_accessions_file, work_dir, num_threads
         )
 
     if run_trnascan:
-        logging.info("Annotating tRNAs")
+        logger.info("Annotating tRNAs")
         run_trnascan_regions(
             genome_file, trnascan_path, trnascan_filter_path, work_dir, num_threads
         )
@@ -5692,7 +5691,7 @@ if __name__ == "__main__":
 
     # Run STAR
     if run_star:
-        logging.info("Running Star")
+        logger.info("Running Star")
         run_star_align(
             star_path,
             trim_fastq,
@@ -5708,19 +5707,19 @@ if __name__ == "__main__":
 
     # Run Scallop
     if run_scallop:
-        logging.info("Running Scallop")
+        logger.info("Running Scallop")
         run_scallop_assemble(scallop_path, stringtie_path, work_dir)
 
     # Run Stringtie
     if run_stringtie:
-        logging.info("Running Stringtie")
+        logger.info("Running Stringtie")
         run_stringtie_assemble(
             stringtie_path, samtools_path, work_dir, genome_file, num_threads
         )
 
     # Run minimap2
     if run_minimap2:
-        logging.info("Running minimap2")
+        logger.info("Running minimap2")
         run_minimap2_align(
             minimap2_path,
             paftools_path,
@@ -5739,7 +5738,7 @@ if __name__ == "__main__":
     #################################
     # Run GenBlast
     if run_genblast:
-        logging.info("Running GenBlast")
+        logger.info("Running GenBlast")
         run_genblast_align(
             genblast_path,
             convert2blastmask_path,
@@ -5753,7 +5752,7 @@ if __name__ == "__main__":
 
     # Run GenBlast on BUSCO set, gives higher priority when creating the final genes in cases where transcriptomic data are missing or fragmented
     if run_busco:
-        logging.info("Running GenBlast of BUSCO proteins")
+        logger.info("Running GenBlast of BUSCO proteins")
         run_genblast_align(
             genblast_path,
             convert2blastmask_path,
@@ -5770,7 +5769,7 @@ if __name__ == "__main__":
     #################################
     # Do some magic
     if finalise_geneset:
-        logging.info("Finalise geneset")
+        logger.info("Finalise geneset")
         run_finalise_geneset(
             main_script_dir,
             work_dir,
@@ -5786,7 +5785,7 @@ if __name__ == "__main__":
     #################################
     # Run Augustus
     if run_augustus:
-        logging.info("Running Augustus")
+        logger.info("Running Augustus")
         run_augustus_predict(augustus_path, work_dir, masked_genome_file, num_threads)
 
     if load_to_ensembl_db:


### PR DESCRIPTION
* use a logger for logging (recommended way of using logging)
* use "handlers" with logger to print output in both the terminal and the log file
* rename log file to `ensembl_anno.log`
* use ISO datetime format in log messages (excluding "T" which decreases readability)
* remove name of the logger used to log the call in log messages, as it's always the same