### PR TITLE
Making sure that child processes are killed after the GenBlast timeout

### DIFF
--- a/ensembl_anno.py
+++ b/ensembl_anno.py
@@ -2391,9 +2391,8 @@ def run_genblast_align(
     masked_genome_file,
     max_intron_length,
     num_threads,
+    genblast_timeout_secs,
 ):
-
-    genblast_timeout_secs = 10800
 
     if not genblast_path:
         genblast_path = "genblast"
@@ -5299,6 +5298,12 @@ if __name__ == "__main__":
         help="Run GenBlast to align protein sequences",
     )
     parser.add_argument(
+        "--genblast_timeout",
+        type=int,
+        help="GenBlast timeout in seconds",
+        default=10800,
+    )
+    parser.add_argument(
         "--run_busco",
         action="store_true",
         help="Run GenBlast to align BUSCO protein sequences",
@@ -5515,6 +5520,7 @@ if __name__ == "__main__":
     convert2blastmask_path = args.convert2blastmask_path
     makeblastdb_path = args.makeblastdb_path
     run_genblast = args.run_genblast
+    genblast_timeout = args.genblast_timeout
     run_busco = args.run_busco
     protein_file = args.protein_file
     busco_protein_file = args.busco_protein_file
@@ -5753,6 +5759,7 @@ if __name__ == "__main__":
             masked_genome_file,
             max_intron_length,
             num_threads,
+            genblast_timeout,
         )
 
     # Run GenBlast on BUSCO set, gives higher priority when creating the final genes in cases where transcriptomic data are missing or fragmented
@@ -5767,6 +5774,7 @@ if __name__ == "__main__":
             masked_genome_file,
             max_intron_length,
             num_threads,
+            genblast_timeout,
         )
 
     #################################


### PR DESCRIPTION
In some cases the child processes survive after the GenBlast command reaches timeout and this prevents the LSF job from finishing.
This PR makes changes according to [this post](https://alexandra-zaharia.github.io/posts/kill-subprocess-and-its-children-on-timeout-python/) to handle timeout more consistently.