### PR TITLE
Update to obtain latest OrthoDB version data automatically

### DIFF
--- a/support_scripts/download_orthodb_proteinset.sh
+++ b/support_scripts/download_orthodb_proteinset.sh
@@ -176,6 +176,6 @@ grep -c -e ">" -I ${BASENAME}*.fa
 
 ## Print command to rename files:
 echo -e -n "\n## Renaming final output files:\n"
-perl ${PERL_SCRIPTS_DIR}/Quick_rename.pl ${BASENAME}_final.out. ${CLADE_NAME}_orth${ODB_VERSION}_proteins. prefix
+perl ${PERL_SCRIPTS_DIR}/quick_rename.pl ${BASENAME}_final.out. ${CLADE_NAME}_orth${ODB_VERSION}_proteins. prefix
 
 exit 1


### PR DESCRIPTION
This is a small update to allow flexibility in which OrthoDB version is defined for data retrieval.

The code now handles changes in Orthodb version automatically by parsing the main OrthoDB data folder (via HTML), allowing grabbing the current and most recent versioned data master files. 

This PR also captures the specific version of OrthoDB used when creating protein sets, and embeds the version into the file finalised protein file name for easier version control and updating of clade protein sets. 