### PR TITLE
missing space in repeat_id

### DIFF
--- a/repeatmasking_utils.py
+++ b/repeatmasking_utils.py
@@ -248,7 +248,7 @@ def create_repeatmasker_gtf(  # pylint: disable=too-many-locals
 
                 gtf_line = (
                     f"{region_name}\tRepeatMasker\trepeat\t{start}\t{end}\t.\t"
-                    f"{strand}\t.\trepeat_id "{repeat_count}"; "
+                    f"{strand}\t.\trepeat_id \"{repeat_count}\"; "
                     f'repeat_name "{repeat_name}"; repeat_class "{repeat_class}"; '
                     f'repeat_type "{repeat_type}"; repeat_start "{repeat_start}"; '
                     f'repeat_end "{repeat_end}"; score "{score}";\n'

--- a/repeatmasking_utils.py
+++ b/repeatmasking_utils.py
@@ -248,7 +248,7 @@ def create_repeatmasker_gtf(  # pylint: disable=too-many-locals
 
                 gtf_line = (
                     f"{region_name}\tRepeatMasker\trepeat\t{start}\t{end}\t.\t"
-                    f"{strand}\t.\trepeat_id{repeat_count}; "
+                    f"{strand}\t.\trepeat_id "{repeat_count}"; "
                     f'repeat_name "{repeat_name}"; repeat_class "{repeat_class}"; '
                     f'repeat_type "{repeat_type}"; repeat_start "{repeat_start}"; '
                     f'repeat_end "{repeat_end}"; score "{score}";\n'


### PR DESCRIPTION
the missing space in the slice gtf is causing multiple assignments for the same id in the final gtf. 
However even if the id is assigned to different repeat this doesn't cause any issue for the loading into the core db because the new id is assigned via repeat feature subroutine in the Perl APIs.